### PR TITLE
compose version downgraded

### DIFF
--- a/dockerfiles/web.yml
+++ b/dockerfiles/web.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '2'
 services:
   web:
     image: $IMAGE


### PR DESCRIPTION
Downgraded as we've seen such an error on:
```[12:05:13][Step 2/2] Version in “./dockerfiles/web.yml” is unsupported. You might be seeing this error because you’re using the wrong Compose file version. Either specify a version of “2" (or “2.0”) and place your service definitions under the `services` key```